### PR TITLE
Fix preview error

### DIFF
--- a/movieprint_gui.py
+++ b/movieprint_gui.py
@@ -7,6 +7,7 @@ import threading
 import queue
 import cv2
 import json # << NEW IMPORT for saving/loading settings
+import video_processing
 from version import __version__
 from tkinterdnd2 import DND_FILES, TkinterDnD
 from PIL import ImageTk, Image


### PR DESCRIPTION
## Summary
- fix missing video processing import

## Testing
- `python -m py_compile movieprint_gui.py movieprint_maker.py image_grid.py video_processing.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_68408a19f5548326a5a9773261704e2c