### PR TITLE
Fix: Automate dependency installation in run.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd

--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,5 @@
 @echo off
-cd /d C:\pyMoviePrint\PyMoviePrint
+cd /d "%~dp0"
+pip install -r requirements.txt
 python movieprint_gui.py
 pause


### PR DESCRIPTION
This commit addresses the `ModuleNotFoundError` by adding a command to `run.bat` that automatically installs the required dependencies from `requirements.txt` before the application starts.

It also improves the script's portability by replacing a hardcoded absolute path with a relative path, allowing it to run from any directory.

Additionally, a `.gitignore` file has been added to prevent Python's compiled cache files from being committed to the repository.