### PR TITLE
Add frames-only export option for MoviePrint selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Compared to simple “every N seconds” contact-sheet scripts, it adds:
 - Background color, spacing, rounded corners, thumbnail rotation.
 - Optional overlays (timecode/frame labels) and optional header.
 - JPEG quality controls and post-save max filesize reduction.
+- Optional **frames-only export** (`--output_frames_only`) to save selected thumbnails as individual files into a folder.
 
 ### Performance & Compatibility
 - FFmpeg-based extraction pipeline.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -140,6 +140,8 @@ python movieprint_maker.py hdr_input.mkv ./output \
 - `--output_filename_suffix`: append to source basename.
 - `--output_filename`: explicit fixed name (custom mode).
 - `--overwrite_mode {overwrite,skip}`: behavior when output exists.
+- `--output_frames_only`: export only the selected frames (no combined MoviePrint image).
+- `--individual_frames_output_dir`: optional base folder where `<movieprint_name>_frames/` folders are created.
 
 ## 5.2 Batch Controls
 

--- a/movieprint_gui.py
+++ b/movieprint_gui.py
@@ -731,6 +731,30 @@ class MoviePrintApp(ctk.CTk, TkinterDnD.DnDWrapper):
         ctk.CTkLabel(parent, text="Output Location:", text_color=Theme.TEXT_MUTED).pack(anchor="w", pady=(15, 0))
         ctk.CTkLabel(parent, text="ℹ Files will be saved alongside source videos.", font=Theme.FONT_BOLD).pack(anchor="w", pady=(0, 5))
 
+        self.output_frames_only_cb = ctk.CTkCheckBox(
+            parent,
+            text="Export individual frames only",
+            variable=self.output_frames_only_var,
+            fg_color=Theme.ACCENT_CYAN,
+            hover_color=Theme.BUTTON_HOVER,
+        )
+        self.output_frames_only_cb.pack(anchor="w", pady=(4, 2))
+
+        frames_dir_frame = ctk.CTkFrame(parent, fg_color="transparent")
+        frames_dir_frame.pack(fill="x", pady=(0, 8))
+        ctk.CTkEntry(
+            frames_dir_frame,
+            textvariable=self.individual_frames_output_dir_var,
+            placeholder_text="Optional folder for exported frames",
+        ).pack(side="left", fill="x", expand=True)
+        ctk.CTkButton(
+            frames_dir_frame,
+            text="Browse",
+            width=70,
+            command=self.browse_output_dir,
+            fg_color=Theme.BG_SECONDARY,
+        ).pack(side="left", padx=(6, 0))
+
         # --- NEW: Overwrite Switch ---
         ctk.CTkLabel(parent, text="Existing Files:").pack(anchor="w", pady=(5,0))
         self.overwrite_seg = ctk.CTkSegmentedButton(parent, values=["overwrite", "skip"], variable=self.overwrite_mode_var,
@@ -1288,6 +1312,8 @@ class MoviePrintApp(ctk.CTk, TkinterDnD.DnDWrapper):
             settings.output_naming_mode = self.output_naming_mode_var.get()
             settings.output_filename_suffix = self.output_filename_suffix_var.get()
             settings.output_filename = self.output_filename_var.get()
+            settings.output_frames_only = self.output_frames_only_var.get()
+            settings.individual_frames_output_dir = self.individual_frames_output_dir_var.get().strip()
             settings.temp_dir = None
             settings.haar_cascade_xml = None
             settings.grid_margin = int(self.grid_margin_var.get())
@@ -1374,7 +1400,10 @@ class MoviePrintApp(ctk.CTk, TkinterDnD.DnDWrapper):
             if path in self.batch_file_list: self.batch_file_list.remove(path)
             self.batch_listbox.delete(i)
 
-    def browse_output_dir(self): pass
+    def browse_output_dir(self):
+        selected = filedialog.askdirectory(title="Select Folder for Individual Frame Exports")
+        if selected:
+            self.individual_frames_output_dir_var.set(selected)
     def pick_bg_color(self):
         c = colorchooser.askcolor(color=self.background_color_var.get())
         if c[1]: self.background_color_var.set(c[1])

--- a/movieprint_maker.py
+++ b/movieprint_maker.py
@@ -369,6 +369,35 @@ def _generate_movieprint(metadata_list, settings, output_path, logger):
     logger.info(f"  MoviePrint successfully saved to {output_path}")
     return True, layout_data, None
 
+
+def _export_individual_frames(metadata_list, output_dir, settings, logger):
+    """Exports selected thumbnails as individual frame files."""
+    os.makedirs(output_dir, exist_ok=True)
+    frame_format = getattr(settings, 'frame_format', 'jpg').lower()
+    copied = []
+
+    for idx, meta in enumerate(metadata_list, 1):
+        source_path = meta.get('frame_path')
+        if not source_path or not os.path.exists(source_path):
+            continue
+
+        timestamp = meta.get('timestamp_sec')
+        if timestamp is None:
+            target_name = f"frame_{idx:04d}.{frame_format}"
+        else:
+            safe_ts = str(round(float(timestamp), 3)).replace('.', 'p')
+            target_name = f"frame_{idx:04d}_{safe_ts}s.{frame_format}"
+
+        target_path = os.path.join(output_dir, target_name)
+        shutil.copy2(source_path, target_path)
+        copied.append(target_path)
+
+    if not copied:
+        return False, "No frames were exported."
+
+    logger.info(f"  Exported {len(copied)} individual frames to {output_dir}")
+    return True, output_dir
+
 def _save_metadata(metadata_list, layout_data, settings, start_sec, end_sec, process_warnings, movieprint_path, logger):
     """Saves metadata JSON. STRICTLY DISABLED if save_metadata_json is False."""
     if not getattr(settings, 'save_metadata_json', False): return
@@ -436,10 +465,29 @@ def process_single_video(video_file_path, settings, effective_output_filename, l
         metadata_list = _limit_frames_for_grid(metadata_list, settings, temp_dir, cleanup_temp, logger)
         metadata_list = _process_thumbnails(metadata_list, settings, logger)
 
-        # 6. Generation
+        # 6. Generation / Export
+        if getattr(settings, 'output_frames_only', False):
+            final_path = os.path.join(target_output_dir, os.path.splitext(effective_output_filename)[0] + "_frames")
+            if getattr(settings, 'individual_frames_output_dir', '').strip():
+                base_dir = os.path.abspath(getattr(settings, 'individual_frames_output_dir').strip())
+                final_path = os.path.join(base_dir, os.path.basename(final_path))
+
+            overwrite_mode = getattr(settings, 'overwrite_mode', 'overwrite')
+            if os.path.exists(final_path):
+                if overwrite_mode == 'skip':
+                    logger.info(f"Skipping frame export for {video_file_path} (Folder exists: {final_path})")
+                    return True, final_path
+                shutil.rmtree(final_path, ignore_errors=True)
+
+            success, message_or_path = _export_individual_frames(metadata_list, final_path, settings, logger)
+            if not success:
+                return False, message_or_path
+            return True, message_or_path
+
         final_path = os.path.join(target_output_dir, effective_output_filename)
         success, layout_data, error_msg = _generate_movieprint(metadata_list, settings, final_path, logger)
-        if not success: return False, error_msg
+        if not success:
+            return False, error_msg
 
         # 7. Post-Processing
         enforce_max_filesize(final_path, settings.max_output_filesize_kb, logger)
@@ -507,10 +555,11 @@ def execute_movieprint_generation(settings, logger, progress_callback=None, fast
         # 2. Skip Check
         target_dir = os.path.dirname(os.path.abspath(video_path))
         full_output_path = os.path.join(target_dir, effective_output_name)
-        
-        if overwrite_mode == 'skip' and os.path.exists(full_output_path):
-            logger.info(f"Skipping {video_path} (Output exists: {effective_output_name})")
-            continue
+
+        if not getattr(settings, 'output_frames_only', False):
+            if overwrite_mode == 'skip' and os.path.exists(full_output_path):
+                logger.info(f"Skipping {video_path} (Output exists: {effective_output_name})")
+                continue
 
         try:
             success, message_or_path = process_single_video(
@@ -587,6 +636,8 @@ def main():
     style_grp.add_argument("--use_gpu", action="store_true")
     style_grp.add_argument("--fast", "--draft", action="store_true", dest="fast_preview")
     style_grp.add_argument("--output_quality", type=int, default=95)
+    style_grp.add_argument("--output_frames_only", action="store_true", help="Export individual selected frames instead of creating a combined MoviePrint image.")
+    style_grp.add_argument("--individual_frames_output_dir", type=str, default="", help="Base directory for individual frame export folders.")
     
     # HDR / Color
     style_grp.add_argument("--hdr_tonemap", action="store_true")

--- a/state_manager.py
+++ b/state_manager.py
@@ -16,6 +16,8 @@ class ProjectSettings:
     output_filename_suffix: str = "_movieprint"
     output_filename: str = ""
     overwrite_mode: str = "overwrite" # NEW: "overwrite" or "skip"
+    output_frames_only: bool = False
+    individual_frames_output_dir: str = ""
 
     # Extraction
     extraction_mode: str = "interval"  # "interval" or "shot"


### PR DESCRIPTION
### Motivation
- Provide an option to export the selected MoviePrint thumbnails as individual image files in a folder instead of producing a single combined MoviePrint image.

### Description
- Added new settings to `ProjectSettings` to carry frames-only behavior: `output_frames_only` and `individual_frames_output_dir` (file: `state_manager.py`).
- Implemented `_export_individual_frames(...)` in `movieprint_maker.py` and branched `process_single_video(...)` to either export individual frames or generate the combined grid image based on `output_frames_only`.
- Added CLI flags `--output_frames_only` and `--individual_frames_output_dir`, and GUI controls (checkbox + folder picker) wired into the generation settings (file: `movieprint_gui.py`).
- Documented the feature in `README.md` and `USER_GUIDE.md` and respected existing overwrite/skip behavior when exporting per-video frame folders.

### Testing
- Compiled sources: `python -m py_compile movieprint_maker.py movieprint_gui.py state_manager.py` (succeeded).
- Attempted end-to-end CLI run to export frames, but runtime failed in this environment due to OpenCV import error caused by missing system library (`libGL.so.1`), so full extraction/export could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada3cc14508326a42174c18344d85d)